### PR TITLE
Extract the dialog into its own separate component/plugin that …

### DIFF
--- a/__tests__/MiradorDownloadDialog.test.js
+++ b/__tests__/MiradorDownloadDialog.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import miradorDownloadDialog from '../src/MiradorDownloadDialog';
+
+/** Utility function to wrap  */
+function createWrapper(props) {
+  return shallow(
+    <miradorDownloadDialog.component
+      canvasLabel={label => (label || 'My Canvas Title')}
+      canvases={[]}
+      classes={{}}
+      closeDialog={() => {}}
+      manifest={{ getSequences: () => [] }}
+      open
+      viewType="single"
+      windowId="wid123"
+      {...props}
+    />,
+  ).dive();
+}
+
+describe('Dialog', () => {
+  let wrapper;
+
+  it('does not render anything if the open prop is false', () => {
+    wrapper = createWrapper({ open: false });
+    expect(wrapper).toEqual({});
+  });
+
+  it('renders a CanvasDownloadLinks componewnt for every canvas', () => {
+    const mockCanvas = id => ({
+      id,
+      getHeight: () => 4000,
+      getWidth: () => 1000,
+      getCanonicalImageUri: () => 'https://example.com/iiif/abc123/full/9000,/0/default.jpg',
+    });
+    wrapper = createWrapper({ canvases: [mockCanvas('abc123'), mockCanvas('xyz321')] });
+    expect(wrapper.find('CanvasDownloadLinks').length).toBe(2);
+  });
+
+  it('has a close button that triggers the closeDialog prop', () => {
+    const closeDialog = jest.fn();
+    wrapper = createWrapper({ closeDialog });
+    wrapper.find('WithStyles(Button)').simulate('click');
+    expect(closeDialog).toHaveBeenCalled();
+  });
+
+  describe('ManifestDownloadLinks', () => {
+    it('is not rendered if hte manifest has no renderings', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.find('ManifestDownloadLinks').length).toBe(0);
+    });
+    it('rendered if the manifest has renderings', () => {
+      const rendering = { id: '', getLabel: () => {}, getFormat: () => {} };
+      wrapper = createWrapper({
+        manifest: {
+          getSequences: () => [
+            { getRenderings: () => [rendering] },
+          ],
+        },
+      });
+
+      expect(wrapper.find('ManifestDownloadLinks').length).toBe(1);
+    });
+  });
+});

--- a/__tests__/miradorDownloadPlugin.test.js
+++ b/__tests__/miradorDownloadPlugin.test.js
@@ -5,15 +5,12 @@ import miradorDownloadPlugin from '../src';
 function createWrapper(props) {
   return shallow(
     <miradorDownloadPlugin.component
-      canvasLabel={label => (label || 'My Canvas Title')}
-      canvases={[]}
-      classes={{}}
-      manifest={{ getSequences: () => [] }}
-      viewType="single"
-      windowId="wid123"
+      handleClose={() => {}}
+      openDownloadDialog={() => {}}
+
       {...props}
     />,
-  ).dive();
+  );
 }
 
 describe('miradorDownloadPlugin', () => {
@@ -28,60 +25,13 @@ describe('miradorDownloadPlugin', () => {
   });
 
   describe('MenuItem', () => {
-    it('udpates the modalDisplayed state which clicked', () => {
-      const wrapper = createWrapper();
-      expect(wrapper.state().modalDisplayed).toBe(false);
+    it('calls the openShareDialog and handleClose props when clicked', () => {
+      const handleClose = jest.fn();
+      const openDownloadDialog = jest.fn();
+      const wrapper = createWrapper({ handleClose, openDownloadDialog });
       wrapper.find('WithStyles(MenuItem)').simulate('click');
-      expect(wrapper.state().modalDisplayed).toBe(true);
-    });
-  });
-
-  describe('Dialog', () => {
-    it('renders a dialog that is open/closed based on the component state', () => {
-      const wrapper = createWrapper();
-      expect(wrapper.state().modalDisplayed).toBe(false);
-      expect(wrapper.find('WithStyles(Dialog)').props().open).toBe(false);
-      wrapper.setState({ modalDisplayed: true });
-      expect(wrapper.find('WithStyles(Dialog)').props().open).toBe(true);
-    });
-
-    it('renders a CanvasDownloadLinks componewnt for every canvas', () => {
-      const mockCanvas = id => ({
-        id,
-        getHeight: () => 4000,
-        getWidth: () => 1000,
-        getCanonicalImageUri: () => 'https://example.com/iiif/abc123/full/9000,/0/default.jpg',
-      });
-      const wrapper = createWrapper({ canvases: [mockCanvas('abc123'), mockCanvas('xyz321')] });
-      expect(wrapper.find('CanvasDownloadLinks').length).toBe(2);
-    });
-
-    it('has a close button that updates the modealDisplay state to false', () => {
-      const wrapper = createWrapper();
-      wrapper.setState({ modalDisplayed: true });
-      expect(wrapper.state().modalDisplayed).toBe(true);
-      wrapper.find('WithStyles(Button)').simulate('click');
-      expect(wrapper.state().modalDisplayed).toBe(false);
-    });
-
-    describe('ManifestDownloadLinks', () => {
-      it('is not rendered if hte manifest has no renderings', () => {
-        const wrapper = createWrapper();
-
-        expect(wrapper.find('ManifestDownloadLinks').length).toBe(0);
-      });
-      it('rendered if the manifest has renderings', () => {
-        const rendering = { id: '', getLabel: () => {}, getFormat: () => {} };
-        const wrapper = createWrapper({
-          manifest: {
-            getSequences: () => [
-              { getRenderings: () => [rendering] },
-            ],
-          },
-        });
-
-        expect(wrapper.find('ManifestDownloadLinks').length).toBe(1);
-      });
+      expect(handleClose).toHaveBeenCalled();
+      expect(openDownloadDialog).toHaveBeenCalled();
     });
   });
 });

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,5 +1,6 @@
 import mirador from 'mirador';
 import miradorDownloadPlugin from '../../src';
+import miradorDownloadDialogPlugin from '../../src/MiradorDownloadDialog';
 import osdReferencePlugin from '../../src/OSDReferences';
 
 const config = {
@@ -16,5 +17,6 @@ const config = {
 
 mirador.viewer(config, [
   osdReferencePlugin,
+  miradorDownloadDialogPlugin,
   miradorDownloadPlugin,
 ]);

--- a/src/MiradorDownloadDialog.js
+++ b/src/MiradorDownloadDialog.js
@@ -1,0 +1,137 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Typography from '@material-ui/core/Typography';
+import { getCanvasLabel, getSelectedCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
+import { getWindowViewType } from 'mirador/dist/es/src/state/selectors/windows';
+import { getManifestoInstance } from 'mirador/dist/es/src/state/selectors/manifests';
+import CanvasDownloadLinks from './CanvasDownloadLinks';
+import ManifestDownloadLinks from './ManifestDownloadLinks';
+
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  closeDialog: () => dispatch({ type: 'CLOSE_WINDOW_DIALOG', windowId }),
+});
+
+const mapStateToProps = (state, { windowId }) => ({
+  canvases: getSelectedCanvases(state, { windowId }),
+  canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
+  manifest: getManifestoInstance(state, { windowId }),
+  open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
+  viewType: getWindowViewType(state, { windowId }),
+});
+
+
+/**
+ * MiradorDownloadDialog ~
+*/
+export class MiradorDownloadDialog extends Component {
+  renderings() {
+    const { manifest } = this.props;
+    if (!(
+      manifest
+      && manifest.getSequences()
+      && manifest.getSequences()[0]
+      && manifest.getSequences()[0].getRenderings()
+    )) return [];
+
+    return manifest.getSequences()[0].getRenderings();
+  }
+
+  /**
+   * Returns the rendered component
+  */
+  render() {
+    const {
+      canvases,
+      canvasLabel,
+      classes,
+      closeDialog,
+      open,
+      viewType,
+      windowId,
+    } = this.props;
+
+    if (!open) return ('');
+
+    return (
+      <React.Fragment>
+        <Dialog
+          disableEnforceFocus
+          onClose={closeDialog}
+          open={open}
+          scroll="paper"
+          fullWidth
+          maxWidth="xs"
+        >
+          <DialogTitle disableTypography className={classes.h2}>
+            <Typography variant="h2">Download</Typography>
+          </DialogTitle>
+          <DialogContent>
+            {canvases.map(canvas => (
+              <CanvasDownloadLinks
+                canvas={canvas}
+                canvasLabel={canvasLabel(canvas.index)}
+                classes={classes}
+                key={canvas.id}
+                viewType={viewType}
+                windowId={windowId}
+              />
+            ))}
+            {this.renderings().length > 0
+              && <ManifestDownloadLinks classes={classes} renderings={this.renderings()} />
+            }
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={closeDialog} color="primary">
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </React.Fragment>
+    );
+  }
+}
+
+MiradorDownloadDialog.propTypes = {
+  canvasLabel: PropTypes.func.isRequired,
+  canvases: PropTypes.arrayOf(
+    PropTypes.shape({ id: PropTypes.string, index: PropTypes.number }),
+  ),
+  classes: PropTypes.shape({
+    h2: PropTypes.string,
+    h3: PropTypes.string,
+  }).isRequired,
+  closeDialog: PropTypes.func.isRequired,
+  manifest: PropTypes.shape({
+    getSequences: PropTypes.func.isRequired,
+  }).isRequired,
+  open: PropTypes.bool,
+  viewType: PropTypes.string.isRequired,
+  windowId: PropTypes.string.isRequired,
+};
+MiradorDownloadDialog.defaultProps = {
+  canvases: [],
+  open: false,
+};
+
+const styles = () => ({
+  h2: {
+    paddingBottom: 0,
+  },
+  h3: {
+    marginTop: '20px',
+  },
+});
+
+export default {
+  target: 'Window',
+  mode: 'add',
+  component: withStyles(styles)(MiradorDownloadDialog),
+  mapDispatchToProps,
+  mapStateToProps,
+};


### PR DESCRIPTION
…attaches itself to Mirador's Window component.

This fixes the keyboard navigation of the WindowTopMenu and this plugin's Dialog.