### PR TITLE
Some housecleaning updates

### DIFF
--- a/__tests__/miradorDownloadPlugin.test.js
+++ b/__tests__/miradorDownloadPlugin.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import miradorDownloadPlugin from '../src';
+import miradorDownloadPlugin from '../src/miradorDownloadPlugin';
 
 function createWrapper(props) {
   return shallow(

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,5 +1,5 @@
 import mirador from 'mirador';
-import miradorDownloadPlugin from '../../src';
+import miradorDownloadPlugin from '../../src/miradorDownloadPlugin';
 import miradorDownloadDialogPlugin from '../../src/MiradorDownloadDialog';
 import osdReferencePlugin from '../../src/OSDReferences';
 
@@ -17,6 +17,6 @@ const config = {
 
 mirador.viewer(config, [
   osdReferencePlugin,
-  miradorDownloadDialogPlugin,
   miradorDownloadPlugin,
+  miradorDownloadDialogPlugin,
 ]);

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,4 +1,4 @@
-import mirador from 'mirador';
+import Mirador from 'mirador/dist/es/src/index';
 import miradorDownloadPlugin from '../../src/miradorDownloadPlugin';
 import miradorDownloadDialogPlugin from '../../src/MiradorDownloadDialog';
 import osdReferencePlugin from '../../src/OSDReferences';
@@ -15,7 +15,7 @@ const config = {
   }],
 };
 
-mirador.viewer(config, [
+Mirador.viewer(config, [
   osdReferencePlugin,
   miradorDownloadPlugin,
   miradorDownloadDialogPlugin,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jest": "^24.8.0",
     "mirador": "^3.0.0-alpha.10",
     "nwb": "0.23.x",
+    "nwb-sass": "^0.9.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
-    "mirador": "^3.0.0-alpha.7",
+    "mirador": "^3.0.0-alpha.10",
     "prop-types": "^15.7.2",
     "react": "16.x",
     "react-dom": "16.x"
@@ -45,7 +45,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.13.0",
     "jest": "^24.8.0",
-    "mirador": "^3.0.0-alpha.7",
+    "mirador": "^3.0.0-alpha.10",
     "nwb": "0.23.x",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
 import miradorDownloadPlugin from './miradorDownloadPlugin';
+import MiradorDownloadDialogPlugin from './MiradorDownloadDialog';
+import OSDReferencesPlugin from './OSDReferences';
 
-export default miradorDownloadPlugin;
+export default {
+  OSDReferencesPlugin,
+  miradorDownloadPlugin,
+  MiradorDownloadDialogPlugin,
+};


### PR DESCRIPTION
The last commit here should start showing production errors when using the es version of Mirador (preferred for webpack type things).