### PR TITLE
Add support for sizes defined in the image API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@ Describe mirador-download-plugin here.
 
 [coveralls-badge]: https://img.shields.io/coveralls/user/repo/master.png?style=flat-square
 [coveralls]: https://coveralls.io/github/user/repo
+
+## Configuration
+
+Configurations for this plugin are injected when Mirador is initialized under the `miradorDownloadPlugin` key.
+
+```js
+...
+  id: 'mirador',
+  miradorDownloadPlugin: {
+    ...
+  }
+...
+```
+
+| Config Key | Type | Description |
+| --- | --- | --- |
+| `restrictDownloadOnSizeDefinition` | boolean (default: false) | If set to true the `Zoomed region` link will not be rendered if the image API returns a single size in the `sizes` section and the single size height/width is the same size or smaller than the reported height/width. |

--- a/__tests__/CanvasDownloadLinks.test.js
+++ b/__tests__/CanvasDownloadLinks.test.js
@@ -12,6 +12,7 @@ function createWrapper(props) {
       canvasLabel="My Canvas Label"
       classes={{}}
       infoResponse={{}}
+      restrictDownloadOnSizeDefinition={false}
       viewType="single"
       windowId="wid123"
       {...props}
@@ -87,6 +88,29 @@ describe('CanvasDownloadLinks', () => {
       wrapper = createWrapper({ canvas, viewType: 'book', windowId: 'zoomedInWindow' });
 
       expect(wrapper.find(Link).length).toBe(2);
+    });
+
+    describe('when the zoom link is set to be restricted', () => {
+      it('has just the whole image link from the sizes and does not present a zoomed region link', () => {
+        wrapper = createWrapper({
+          canvas,
+          infoResponse: {
+            json: {
+              width: 4000,
+              height: 1000,
+              sizes: [{
+                width: 400,
+                height: 100,
+              }],
+            },
+          },
+          restrictDownloadOnSizeDefinition: true,
+          windowId: 'zoomedInWindow',
+        });
+
+        expect(wrapper.find(Link).length).toBe(1);
+        expect(wrapper.find(Link).props().children).toEqual('Whole image (400 x 100px)');
+      });
     });
   });
 

--- a/__tests__/CanvasDownloadLinks.test.js
+++ b/__tests__/CanvasDownloadLinks.test.js
@@ -11,6 +11,7 @@ function createWrapper(props) {
       canvasId="abc123"
       canvasLabel="My Canvas Label"
       classes={{}}
+      infoResponse={{}}
       viewType="single"
       windowId="wid123"
       {...props}
@@ -63,17 +64,6 @@ describe('CanvasDownloadLinks', () => {
     ).toEqual('My Canvas Label');
   });
 
-  it('renders a link to the whole image', () => {
-    wrapper = createWrapper({ canvas });
-    expect(
-      wrapper
-        .find(Link)
-        .find({ href: 'http://example.com/iiif/abc123/full/full/0/default.jpg?download=true' })
-        .props()
-        .children,
-    ).toEqual('Whole image (4000 x 1000px)');
-  });
-
   describe('Zoomed region link', () => {
     it('is not present when the current zoom is the same as the home zoom', () => {
       wrapper = createWrapper({ canvas });
@@ -100,30 +90,59 @@ describe('CanvasDownloadLinks', () => {
     });
   });
 
-  describe('when the image is > 1000px wide', () => {
-    it('renders a link to a small image (1000px wide), and calculates the correct height', () => {
-      wrapper = createWrapper({ canvas });
-      expect(wrapper.find(Link).length).toEqual(2);
-      expect(
-        wrapper
-          .find(Link)
-          .find({ href: 'http://example.com/iiif/abc123/full/1000,/0/default.jpg?download=true' })
-          .length,
-      ).toEqual(1);
-      expect(
-        wrapper
-          .find(Link)
-          .find({ href: 'http://example.com/iiif/abc123/full/1000,/0/default.jpg?download=true' })
-          .props().children,
-      ).toEqual('Whole image (1000 x 250px)');
+  describe('when there is are sizes defined in the infoResponse', () => {
+    const sizes = [
+      { width: 4000, height: 1000 },
+      { width: 2000, height: 500 },
+      { width: 1000, height: 250 },
+    ];
+    it('uses those sizes for links in the download dialog', () => {
+      wrapper = createWrapper({ canvas, infoResponse: { json: { sizes } } });
+
+      // console.log(wrapper.debug());
+      expect(wrapper.find(Link).at(0).props().children).toEqual('Whole image (4000 x 1000px)');
+      expect(wrapper.find(Link).at(1).props().children).toEqual('Whole image (2000 x 500px)');
+      expect(wrapper.find(Link).at(2).props().children).toEqual('Whole image (1000 x 250px)');
     });
   });
 
-  describe('when the image is < 1000px wide', () => {
-    it('does not render a link to a small image', () => {
-      canvas.getWidth = () => 999;
+  describe('when there are no defined sizes', () => {
+    it('renders a link to the whole image', () => {
       wrapper = createWrapper({ canvas });
-      expect(wrapper.find(Link).length).toEqual(1); // Does not include the 2nd link
+      expect(
+        wrapper
+          .find(Link)
+          .find({ href: 'http://example.com/iiif/abc123/full/full/0/default.jpg?download=true' })
+          .props()
+          .children,
+      ).toEqual('Whole image (4000 x 1000px)');
+    });
+
+    describe('when the image is > 1000px wide', () => {
+      it('renders a link to a small image (1000px wide), and calculates the correct height', () => {
+        wrapper = createWrapper({ canvas });
+        expect(wrapper.find(Link).length).toEqual(2);
+        expect(
+          wrapper
+            .find(Link)
+            .find({ href: 'http://example.com/iiif/abc123/full/1000,/0/default.jpg?download=true' })
+            .length,
+        ).toEqual(1);
+        expect(
+          wrapper
+            .find(Link)
+            .find({ href: 'http://example.com/iiif/abc123/full/1000,/0/default.jpg?download=true' })
+            .props().children,
+        ).toEqual('Whole image (1000 x 250px)');
+      });
+    });
+
+    describe('when the image is < 1000px wide', () => {
+      it('does not render a link to a small image', () => {
+        canvas.getWidth = () => 999;
+        wrapper = createWrapper({ canvas });
+        expect(wrapper.find(Link).length).toEqual(1); // Does not include the 2nd link
+      });
     });
   });
 });

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,13 +5,19 @@ import osdReferencePlugin from '../../src/OSDReferences';
 
 const config = {
   id: 'demo',
+  miradorDownloadPlugin: {
+    restrictDownloadOnSizeDefinition: true,
+  },
   windows: [{
-    loadedManifest: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest',
+    loadedManifest: 'https://purl.stanford.edu/bb020ty1503/iiif/manifest',
   },
   {
     loadedManifest: 'https://scta.info/iiif/graciliscommentary/lon/manifest',
     view: 'book',
     canvasIndex: 3,
+  },
+  {
+    loadedManifest: 'https://purl.stanford.edu/xh756kf1140/iiif/manifest',
   }],
 };
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "peerDependencies": {
     "@material-ui/core": "^4.1.0",
     "@material-ui/icons": "^4.1.0",
+    "lodash.uniqby": "^4.7.0",
     "mirador": "^3.0.0-alpha.12",
     "prop-types": "^15.7.2",
     "react": "16.x",
@@ -45,6 +46,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.13.0",
     "jest": "^24.8.0",
+    "lodash.uniqby": "^4.7.0",
     "mirador": "^3.0.0-alpha.12",
     "node-sass": "^4.12.0",
     "nwb": "0.23.x",

--- a/src/CanvasDownloadLinks.js
+++ b/src/CanvasDownloadLinks.js
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import Link from '@material-ui/core/Link';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import uniqBy from 'lodash.uniqby';
 import { OSDReferences } from './OSDReferences';
 
 
@@ -37,6 +38,12 @@ export default class CanvasDownloadLinks extends Component {
     );
 
     return `${boundsUrl}?download=true`;
+  }
+
+  imageUrlForSize(size) {
+    const { canvas } = this.props;
+
+    return `${canvas.getCanonicalImageUri(size.width)}?download=true`;
   }
 
   fullImageUrl() {
@@ -73,11 +80,56 @@ export default class CanvasDownloadLinks extends Component {
   }
 
   /**
+   * This only returns unique sizes
+  */
+  definedSizes() {
+    const { infoResponse } = this.props;
+    if (!(infoResponse && infoResponse.json && infoResponse.json.sizes)) return [];
+
+    return uniqBy(infoResponse.json.sizes, size => `${size.width}${size.height}`);
+  }
+
+  fullImageLink() {
+    return (
+      <ListItem disableGutters divider key={this.fullImageUrl()}>
+        <Link href={this.fullImageUrl()} rel="noopener noreferrer" target="_blank" variant="body1">
+          {this.fullImageLabel()}
+        </Link>
+      </ListItem>
+    );
+  }
+
+  thousandPixelWideLink() {
+    const { canvas } = this.props;
+
+    if (canvas.getWidth() < 1000) return '';
+
+    return (
+      <ListItem disableGutters divider key={this.thousandPixelWideImage()}>
+        <Link href={this.thousandPixelWideImage()} rel="noopener noreferrer" target="_blank" variant="body1">
+          {this.smallImageLabel()}
+        </Link>
+      </ListItem>
+    );
+  }
+
+  linksForDefinedSizes() {
+    return (
+      this.definedSizes().map(size => (
+        <ListItem disableGutters divider key={`${size.width}${size.height}`}>
+          <Link href={this.imageUrlForSize(size)} rel="noopener noreferrer" target="_blank" variant="body1">
+            {`Whole image (${size.width} x ${size.height}px)`}
+          </Link>
+        </ListItem>
+      ))
+    );
+  }
+
+  /**
    * Returns the rendered component
   */
   render() {
     const {
-      canvas,
       canvasLabel,
       classes,
     } = this.props;
@@ -95,20 +147,10 @@ export default class CanvasDownloadLinks extends Component {
               </ListItem>
             )
           }
-          <ListItem disableGutters divider>
-            <Link href={this.fullImageUrl()} rel="noopener noreferrer" target="_blank" variant="body1">
-              {this.fullImageLabel()}
-            </Link>
-          </ListItem>
-          {(canvas.getWidth() > 1000)
-            && (
-            <ListItem disableGutters divider>
-              <Link href={this.thousandPixelWideImage()} rel="noopener noreferrer" target="_blank" variant="body1">
-                {this.smallImageLabel()}
-              </Link>
-            </ListItem>
-            )
-          }
+          {this.definedSizes().length === 0
+            && ([this.fullImageLink(), this.thousandPixelWideLink()])}
+          {this.definedSizes().length > 0
+            && (this.linksForDefinedSizes())}
         </List>
       </React.Fragment>
     );
@@ -125,6 +167,13 @@ CanvasDownloadLinks.propTypes = {
   canvasLabel: PropTypes.string.isRequired, // canvasLabel is passed because we need access to redux
   classes: PropTypes.shape({
     h3: PropTypes.string,
+  }).isRequired,
+  infoResponse: PropTypes.shape({
+    json: PropTypes.shape({
+      sizes: PropTypes.arrayOf(
+        PropTypes.shape({ height: PropTypes.number, width: PropTypes.number }),
+      ),
+    }),
   }).isRequired,
   viewType: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,

--- a/src/CanvasDownloadLinks.js
+++ b/src/CanvasDownloadLinks.js
@@ -72,10 +72,22 @@ export default class CanvasDownloadLinks extends Component {
     }, {});
   }
 
+  definedSizesRestrictsDownload() {
+    const { infoResponse } = this.props;
+    const { height, width } = infoResponse.json;
+
+    if (this.definedSizes().length !== 1) return false;
+
+    return this.definedSizes()[0].width <= width
+           && this.definedSizes()[0].height <= height;
+  }
+
   displayCurrentZoomLink() {
-    const { viewType } = this.props;
+    const { restrictDownloadOnSizeDefinition, viewType } = this.props;
 
     if (viewType === 'book') return false;
+    if (restrictDownloadOnSizeDefinition && this.definedSizesRestrictsDownload()) return false;
+
     return this.osdViewport().getZoom() > this.osdViewport().getHomeZoom();
   }
 
@@ -175,6 +187,7 @@ CanvasDownloadLinks.propTypes = {
       ),
     }),
   }).isRequired,
+  restrictDownloadOnSizeDefinition: PropTypes.bool.isRequired,
   viewType: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };

--- a/src/MiradorDownloadDialog.js
+++ b/src/MiradorDownloadDialog.js
@@ -7,7 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Typography from '@material-ui/core/Typography';
-import { getCanvasLabel, getSelectedCanvases } from 'mirador/dist/es/src/state/selectors/canvases';
+import { getCanvasLabel, getSelectedCanvases, selectInfoResponse } from 'mirador/dist/es/src/state/selectors/canvases';
 import { getWindowViewType } from 'mirador/dist/es/src/state/selectors/windows';
 import { getManifestoInstance } from 'mirador/dist/es/src/state/selectors/manifests';
 import CanvasDownloadLinks from './CanvasDownloadLinks';
@@ -17,13 +17,17 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
   closeDialog: () => dispatch({ type: 'CLOSE_WINDOW_DIALOG', windowId }),
 });
 
-const mapStateToProps = (state, { windowId }) => ({
-  canvases: getSelectedCanvases(state, { windowId }),
-  canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
-  manifest: getManifestoInstance(state, { windowId }),
-  open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
-  viewType: getWindowViewType(state, { windowId }),
-});
+const mapStateToProps = (state, { windowId }) => {
+  const infoResponse = selectInfoResponse(state, { windowId });
+  return {
+    canvases: getSelectedCanvases(state, { windowId }),
+    canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
+    infoResponse,
+    manifest: getManifestoInstance(state, { windowId }),
+    open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
+    viewType: getWindowViewType(state, { windowId }),
+  };
+};
 
 
 /**
@@ -51,6 +55,7 @@ export class MiradorDownloadDialog extends Component {
       canvasLabel,
       classes,
       closeDialog,
+      infoResponse,
       open,
       viewType,
       windowId,
@@ -77,6 +82,7 @@ export class MiradorDownloadDialog extends Component {
                 canvas={canvas}
                 canvasLabel={canvasLabel(canvas.index)}
                 classes={classes}
+                infoResponse={infoResponse}
                 key={canvas.id}
                 viewType={viewType}
                 windowId={windowId}
@@ -107,6 +113,9 @@ MiradorDownloadDialog.propTypes = {
     h3: PropTypes.string,
   }).isRequired,
   closeDialog: PropTypes.func.isRequired,
+  infoResponse: PropTypes.shape({
+    json: PropTypes.object,
+  }),
   manifest: PropTypes.shape({
     getSequences: PropTypes.func.isRequired,
   }).isRequired,
@@ -116,6 +125,7 @@ MiradorDownloadDialog.propTypes = {
 };
 MiradorDownloadDialog.defaultProps = {
   canvases: [],
+  infoResponse: {},
   open: false,
 };
 

--- a/src/MiradorDownloadDialog.js
+++ b/src/MiradorDownloadDialog.js
@@ -17,17 +17,18 @@ const mapDispatchToProps = (dispatch, { windowId }) => ({
   closeDialog: () => dispatch({ type: 'CLOSE_WINDOW_DIALOG', windowId }),
 });
 
-const mapStateToProps = (state, { windowId }) => {
-  const infoResponse = selectInfoResponse(state, { windowId });
-  return {
-    canvases: getSelectedCanvases(state, { windowId }),
-    canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
-    infoResponse,
-    manifest: getManifestoInstance(state, { windowId }),
-    open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
-    viewType: getWindowViewType(state, { windowId }),
-  };
-};
+const mapStateToProps = (state, { windowId }) => ({
+  canvases: getSelectedCanvases(state, { windowId }),
+  canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
+  infoResponse: selectInfoResponse(state, { windowId }),
+  manifest: getManifestoInstance(state, { windowId }),
+  restrictDownloadOnSizeDefinition: state.config.miradorDownloadPlugin
+                                    && state.config
+                                      .miradorDownloadPlugin
+                                      .restrictDownloadOnSizeDefinition,
+  open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
+  viewType: getWindowViewType(state, { windowId }),
+});
 
 
 /**
@@ -57,6 +58,7 @@ export class MiradorDownloadDialog extends Component {
       closeDialog,
       infoResponse,
       open,
+      restrictDownloadOnSizeDefinition,
       viewType,
       windowId,
     } = this.props;
@@ -83,6 +85,7 @@ export class MiradorDownloadDialog extends Component {
                 canvasLabel={canvasLabel(canvas.index)}
                 classes={classes}
                 infoResponse={infoResponse}
+                restrictDownloadOnSizeDefinition={restrictDownloadOnSizeDefinition}
                 key={canvas.id}
                 viewType={viewType}
                 windowId={windowId}
@@ -117,16 +120,19 @@ MiradorDownloadDialog.propTypes = {
     json: PropTypes.object,
   }),
   manifest: PropTypes.shape({
-    getSequences: PropTypes.func.isRequired,
-  }).isRequired,
+    getSequences: PropTypes.func,
+  }),
   open: PropTypes.bool,
+  restrictDownloadOnSizeDefinition: PropTypes.bool,
   viewType: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };
 MiradorDownloadDialog.defaultProps = {
   canvases: [],
   infoResponse: {},
+  manifest: {},
   open: false,
+  restrictDownloadOnSizeDefinition: false,
 };
 
 const styles = () => ({


### PR DESCRIPTION
Closes #13 
Closes #26 

I have updated the images that are loaded:
* Left: Image that provides sizes
* Top Right: One of Stanford's download restricted images
  * There is a caveat about the reported dimensions, but I think that's an issue we may want to resolve on our end.
* Bottom Right: A service that does not report sizes