### PR TITLE
Change how we determine if a zoomed region link should be displayed.

### DIFF
--- a/src/CanvasDownloadLinks.js
+++ b/src/CanvasDownloadLinks.js
@@ -83,12 +83,17 @@ export default class CanvasDownloadLinks extends Component {
   }
 
   displayCurrentZoomLink() {
-    const { restrictDownloadOnSizeDefinition, viewType } = this.props;
+    const { restrictDownloadOnSizeDefinition, infoResponse, viewType } = this.props;
+    const bounds = this.currentBounds();
 
     if (viewType === 'book') return false;
     if (restrictDownloadOnSizeDefinition && this.definedSizesRestrictsDownload()) return false;
+    if (!(infoResponse && infoResponse.json)) return false;
 
-    return this.osdViewport().getZoom() > this.osdViewport().getHomeZoom();
+    return bounds.height < infoResponse.json.height
+      && bounds.width < infoResponse.json.width
+      && bounds.x >= 0
+      && bounds.y >= 0;
   }
 
   /**


### PR DESCRIPTION
Fixes #31

Instead of determining if the current zoom has been changed from the home zoom
we are now checking if the current height/width is less than the image heigh/width
(also ensuring we don't try to render a link to w/ a negative x/y value)

