### PR TITLE
Pass canvasIndex to the selectInfoResponse selector …

### DIFF
--- a/__tests__/MiradorDownloadDialog.test.js
+++ b/__tests__/MiradorDownloadDialog.test.js
@@ -12,6 +12,7 @@ function createWrapper(props) {
       classes={{}}
       closeDialog={() => {}}
       containerId="container-123"
+      infoResponse={() => ({})}
       manifest={{ getSequences: () => [] }}
       open
       viewType="single"
@@ -64,6 +65,84 @@ describe('Dialog', () => {
       });
 
       expect(wrapper.find('ManifestDownloadLinks').length).toBe(1);
+    });
+  });
+});
+
+describe('mapStateToProps', () => {
+  const state = {
+    infoResponses: {
+      'https://example.com/image/iiif/abc123_0001': {
+        json: {
+          width: 2579,
+          height: 3638,
+          sizes: [
+            {
+              width: 81,
+              height: 114,
+            },
+            {
+              width: 161,
+              height: 227,
+            },
+            {
+              width: 322,
+              height: 455,
+            },
+            {
+              width: 645,
+              height: 909,
+            },
+            {
+              width: 1290,
+              height: 1819,
+            },
+            {
+              width: 2579,
+              height: 3638,
+            },
+          ],
+        },
+      },
+    },
+    manifests: {
+      'http://example.com/abc123/iiif/manifest': {
+        json: {
+          '@type': 'sc:Manifest',
+          sequences: [
+            {
+              canvases: [
+                {
+                  images: [
+                    {
+                      resource: {
+                        service: {
+                          '@id': 'https://example.com/image/iiif/abc123_0001',
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    windows: {
+      'window-abc123': {
+        manifestId: 'http://example.com/abc123/iiif/manifest',
+      },
+    },
+    windowDialogs: {},
+    config: {},
+  };
+  const props = { windowId: 'window-abc123' };
+  const mapStateToProps = miradorDownloadDialog.mapStateToProps(state, props);
+
+  describe('infoResponse', () => {
+    it('gets the correct info response from state', () => {
+      expect(mapStateToProps.infoResponse(0).json.sizes.length).toBe(6);
     });
   });
 });

--- a/src/MiradorDownloadDialog.js
+++ b/src/MiradorDownloadDialog.js
@@ -22,7 +22,7 @@ const mapStateToProps = (state, { windowId }) => ({
   canvases: getVisibleCanvases(state, { windowId }),
   canvasLabel: canvasIndex => (getCanvasLabel(state, { canvasIndex, windowId })),
   containerId: getContainerId(state),
-  infoResponse: selectInfoResponse(state, { windowId }) || {},
+  infoResponse: canvasIndex => (selectInfoResponse(state, { windowId, canvasIndex }) || {}),
   manifest: getManifestoInstance(state, { windowId }),
   restrictDownloadOnSizeDefinition: state.config.miradorDownloadPlugin
                                     && state.config
@@ -88,7 +88,7 @@ export class MiradorDownloadDialog extends Component {
                 canvas={canvas}
                 canvasLabel={canvasLabel(canvas.index)}
                 classes={classes}
-                infoResponse={infoResponse}
+                infoResponse={infoResponse(canvas.index)}
                 restrictDownloadOnSizeDefinition={restrictDownloadOnSizeDefinition}
                 key={canvas.id}
                 viewType={viewType}
@@ -121,9 +121,7 @@ MiradorDownloadDialog.propTypes = {
   }).isRequired,
   closeDialog: PropTypes.func.isRequired,
   containerId: PropTypes.string.isRequired,
-  infoResponse: PropTypes.shape({
-    json: PropTypes.object,
-  }),
+  infoResponse: PropTypes.func.isRequired,
   manifest: PropTypes.shape({
     getSequences: PropTypes.func,
   }),
@@ -134,7 +132,6 @@ MiradorDownloadDialog.propTypes = {
 };
 MiradorDownloadDialog.defaultProps = {
   canvases: [],
-  infoResponse: {},
   manifest: {},
   open: false,
   restrictDownloadOnSizeDefinition: false,


### PR DESCRIPTION
…(so it knows which infoResponse to return)

Example Manifest: https://purl.stanford.edu/dh543mm5405/iiif/manifest ([first image](https://stacks.stanford.edu/image/iiif/dh543mm5405%252Fdh543mm5405_0001/info.json))

## Before
<img width="520" alt="before screenshot" src="https://user-images.githubusercontent.com/96776/73484072-80c69300-4355-11ea-8d16-ba43d217d4c1.png">

## After 
<img width="513" alt="after screenshot" src="https://user-images.githubusercontent.com/96776/73484073-80c69300-4355-11ea-911e-8f3a439b18c4.png">
