### PR TITLE
Configurable download query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configurations for this plugin are injected when Mirador is initialized under th
 | Config Key | Type | Description |
 | --- | --- | --- |
 | `restrictDownloadOnSizeDefinition` | boolean (default: false) | If set to true the `Zoomed region` link will not be rendered if the image API returns a single size in the `sizes` section and the single size height/width is the same size or smaller than the reported height/width. |
+| `downloadQueryString` | string (default: download=true) | Query string passed to IIIF image server to request download of image. |
 
 ## Contribute
 Mirador's development, design, and maintenance is driven by community needs and ongoing feedback and discussion. Join us at our regularly scheduled community calls, on [IIIF slack #mirador](http://bit.ly/iiif-slack), or the [mirador-tech](https://groups.google.com/forum/#!forum/mirador-tech) and [iiif-discuss](https://groups.google.com/forum/#!forum/iiif-discuss) mailing lists. To suggest features, report bugs, and clarify usage, please submit a GitHub issue.

--- a/__tests__/CanvasDownloadLinks.test.js
+++ b/__tests__/CanvasDownloadLinks.test.js
@@ -14,6 +14,7 @@ function createWrapper(props) {
       classes={{}}
       infoResponse={{}}
       restrictDownloadOnSizeDefinition={false}
+      downloadQueryString="download=true"
       viewType="single"
       windowId="wid123"
       {...props}
@@ -215,6 +216,18 @@ describe('CanvasDownloadLinks', () => {
         canvas.getWidth = () => 999;
         wrapper = createWrapper({ canvas });
         expect(wrapper.find(Link).length).toEqual(1); // Does not include the 2nd link
+      });
+    });
+
+    describe('when there is configured download query string', () => {
+      it('has image href with configured download query string', () => {
+        wrapper = createWrapper({ canvas, downloadQueryString: 'response-content-disposition=attachment' });
+        expect(
+          wrapper
+            .find(Link)
+            .find({ href: 'http://example.com/iiif/abc123/full/full/0/default.jpg?response-content-disposition=attachment' })
+            .length,
+        ).toEqual(1);
       });
     });
   });

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,6 +5,7 @@ const config = {
   id: 'demo',
   miradorDownloadPlugin: {
     restrictDownloadOnSizeDefinition: true,
+    downloadQueryString: 'download=true',
   },
   windows: [{
     loadedManifest: 'https://purl.stanford.edu/bb020ty1503/iiif/manifest',

--- a/src/CanvasDownloadLinks.js
+++ b/src/CanvasDownloadLinks.js
@@ -31,32 +31,32 @@ export default class CanvasDownloadLinks extends Component {
   }
 
   zoomedImageUrl() {
-    const { canvas } = this.props;
+    const { canvas, downloadQueryString } = this.props;
     const bounds = this.currentBounds();
     const boundsUrl = canvas.getCanonicalImageUri().replace(
       /\/full\/.*\/0\//,
       `/${bounds.x},${bounds.y},${bounds.width},${bounds.height}/full/0/`,
     );
 
-    return `${boundsUrl}?download=true`;
+    return `${boundsUrl}?${downloadQueryString}`;
   }
 
   imageUrlForSize(size) {
-    const { canvas } = this.props;
+    const { canvas, downloadQueryString } = this.props;
 
-    return `${canvas.getCanonicalImageUri(size.width)}?download=true`;
+    return `${canvas.getCanonicalImageUri(size.width)}?${downloadQueryString}`;
   }
 
   fullImageUrl() {
-    const { canvas } = this.props;
+    const { canvas, downloadQueryString } = this.props;
 
-    return `${canvas.getCanonicalImageUri().replace(/\/full\/.*\/0\//, '/full/full/0/')}?download=true`;
+    return `${canvas.getCanonicalImageUri().replace(/\/full\/.*\/0\//, '/full/full/0/')}?${downloadQueryString}`;
   }
 
   thousandPixelWideImage() {
-    const { canvas } = this.props;
+    const { canvas, downloadQueryString } = this.props;
 
-    return `${canvas.getCanonicalImageUri('1000')}?download=true`;
+    return `${canvas.getCanonicalImageUri('1000')}?${downloadQueryString}`;
   }
 
   osdViewport() {
@@ -203,6 +203,7 @@ CanvasDownloadLinks.propTypes = {
     }),
   }).isRequired,
   restrictDownloadOnSizeDefinition: PropTypes.bool.isRequired,
+  downloadQueryString: PropTypes.string.isRequired,
   viewType: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };

--- a/src/MiradorDownloadDialog.js
+++ b/src/MiradorDownloadDialog.js
@@ -28,6 +28,10 @@ const mapStateToProps = (state, { windowId }) => ({
                                     && state.config
                                       .miradorDownloadPlugin
                                       .restrictDownloadOnSizeDefinition,
+  downloadQueryString: state.config.miradorDownloadPlugin
+                       && state.config
+                         .miradorDownloadPlugin
+                         .downloadQueryString,
   open: (state.windowDialogs[windowId] && state.windowDialogs[windowId].openDialog === 'download'),
   viewType: getWindowViewType(state, { windowId }),
 });
@@ -62,6 +66,7 @@ export class MiradorDownloadDialog extends Component {
       infoResponse,
       open,
       restrictDownloadOnSizeDefinition,
+      downloadQueryString,
       viewType,
       windowId,
     } = this.props;
@@ -90,6 +95,7 @@ export class MiradorDownloadDialog extends Component {
                 classes={classes}
                 infoResponse={infoResponse(canvas.id)}
                 restrictDownloadOnSizeDefinition={restrictDownloadOnSizeDefinition}
+                downloadQueryString={downloadQueryString}
                 key={canvas.id}
                 viewType={viewType}
                 windowId={windowId}
@@ -127,6 +133,7 @@ MiradorDownloadDialog.propTypes = {
   }),
   open: PropTypes.bool,
   restrictDownloadOnSizeDefinition: PropTypes.bool,
+  downloadQueryString: PropTypes.string,
   viewType: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };
@@ -135,6 +142,7 @@ MiradorDownloadDialog.defaultProps = {
   manifest: {},
   open: false,
   restrictDownloadOnSizeDefinition: false,
+  downloadQueryString: 'download=true',
 };
 
 const styles = () => ({


### PR DESCRIPTION
Makes IIIF Image URL query string configurable. This affords using a cantaloupe IIIF Image Server.

https://cantaloupe-project.github.io/manual/5.0/endpoints.html#Response%20Content%20Disposition